### PR TITLE
Raise PermissionDenied instad of returning HttpResponseForbidden

### DIFF
--- a/inviter2/views.py
+++ b/inviter2/views.py
@@ -4,8 +4,9 @@ import importlib
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponseRedirect, HttpResponseForbidden
+from django.http import Http404, HttpResponseRedirect
 from django.utils.http import base36_to_int
 from django.views.generic.base import TemplateView
 
@@ -64,7 +65,7 @@ class UserMixin(object):
         user = self.get_user(uidb36)
 
         if not self.token_generator.check_token(user, token):
-            return HttpResponseForbidden()
+            raise PermissionDenied
 
         return super(UserMixin, self).dispatch(request, user, *args, **kwargs)
 


### PR DESCRIPTION
This PR changes how "token mismatch detected" is handled. Instead of returning `HttpResponseForbidden`, `UserMixin` now raises `django.core.exceptions.PermissionDenied`.

This allows Django to use the [The 403 (HTTP Forbidden) view](https://docs.djangoproject.com/en/1.11/ref/views/#the-403-http-forbidden-view) mechanism. This will show a custom error page, if the user has configured `django.views.defaults.permission_denied` or has a `403.html` template in their root template directory.